### PR TITLE
[#28] 외부 DTO의 데이터를 Command 객체로 전달받아 내부 서비스 로직이 직접적으로 외부 DTO와 소통하지 않도록 의존성 방향 수정

### DIFF
--- a/src/main/java/org/wedding/adapter/in/web/CardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardController.java
@@ -11,8 +11,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.wedding.adapter.in.web.dto.CreateCardRequest;
 import org.wedding.adapter.in.web.dto.ModifyCardRequest;
-import org.wedding.application.port.in.usecase.CreateCardUseCase;
-import org.wedding.application.port.in.usecase.ModifyCardUseCase;
+import org.wedding.application.port.in.command.card.CreateCardCommand;
+import org.wedding.application.port.in.usecase.card.CreateCardUseCase;
+import org.wedding.application.port.in.usecase.card.ModifyCardUseCase;
 import org.wedding.common.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,7 +36,11 @@ public class CardController {
     @Operation(summary = "카드 생성", description = "카드 생성")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<ApiResponse<Void>> createCard(@RequestBody @Valid CreateCardRequest request) {
-        createCardUseCase.createCard(request);
+
+        CreateCardCommand command = new CreateCardCommand(request.cardTitle(), request.budget(), request.deadline());
+
+        createCardUseCase.createCard(command);
+
         ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.CREATED, "카드가 생성되었습니다.");
         return new ResponseEntity<>(response, response.status());
     }

--- a/src/main/java/org/wedding/adapter/in/web/CardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.wedding.adapter.in.web.dto.CreateCardRequest;
 import org.wedding.adapter.in.web.dto.ModifyCardRequest;
 import org.wedding.application.port.in.command.card.CreateCardCommand;
+import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.in.usecase.card.CreateCardUseCase;
 import org.wedding.application.port.in.usecase.card.ModifyCardUseCase;
 import org.wedding.common.response.ApiResponse;
@@ -51,7 +52,11 @@ public class CardController {
     public ResponseEntity<ApiResponse<Void>> modifyCard(
         @PathVariable int cardId,
         @RequestBody @Valid ModifyCardRequest request) {
-        modifyCardUseCase.modifyCard(cardId, request);
+
+        ModifyCardCommand command = new ModifyCardCommand(request.cardTitle(), request.budget(), request.deadline(), request.cardStatus());
+
+        modifyCardUseCase.modifyCard(cardId, command);
+
         ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.OK, "카드가 수정되었습니다.");
         return new ResponseEntity<>(response, response.status());
     }

--- a/src/main/java/org/wedding/adapter/in/web/dto/CreateCardRequest.java
+++ b/src/main/java/org/wedding/adapter/in/web/dto/CreateCardRequest.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 
 @Builder
 public record CreateCardRequest (
+
     @NotBlank(message = "CARD_TITLE_IS_REQUIRED", payload = CardError.class)
     @Size(min = 1, max = 20, message = "CARD_TITLE_SIZE_NOT_VALID", payload = CardError.class)
     String cardTitle,
@@ -34,15 +35,6 @@ public record CreateCardRequest (
 
     public CreateCardRequest(String cardTitle, LocalDateTime deadline) {
         this(cardTitle, null, deadline);
-    }
-
-    public static Card toEntity(CreateCardRequest createCardRequest) {
-        return Card.builder()
-            .cardTitle(createCardRequest.cardTitle())
-            .budget(createCardRequest.budget())
-            .deadline(createCardRequest.deadline())
-            .cardStatus(CardStatus.BACKLOG)
-            .build();
     }
 
     public String toString() {

--- a/src/main/java/org/wedding/adapter/in/web/dto/CreateCardRequest.java
+++ b/src/main/java/org/wedding/adapter/in/web/dto/CreateCardRequest.java
@@ -2,8 +2,6 @@ package org.wedding.adapter.in.web.dto;
 
 import java.time.LocalDateTime;
 
-import org.wedding.domain.CardStatus;
-import org.wedding.domain.card.Card;
 import org.wedding.domain.card.exception.CardError;
 
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/org/wedding/adapter/in/web/dto/ModifyCardRequest.java
+++ b/src/main/java/org/wedding/adapter/in/web/dto/ModifyCardRequest.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 
 @Builder
 public record ModifyCardRequest (
+
     Optional<String> cardTitle,
     Optional<Long> budget,
     Optional<LocalDateTime> deadline,

--- a/src/main/java/org/wedding/application/port/in/command/card/CreateCardCommand.java
+++ b/src/main/java/org/wedding/application/port/in/command/card/CreateCardCommand.java
@@ -1,0 +1,44 @@
+package org.wedding.application.port.in.command.card;
+
+import java.time.LocalDateTime;
+
+import org.wedding.domain.CardStatus;
+import org.wedding.domain.card.Card;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record CreateCardCommand (
+
+    @NotNull
+    String cardTitle,
+    Long budget,
+    LocalDateTime deadline
+) {
+
+    public CreateCardCommand(String cardTitle, Long budget, LocalDateTime deadline) {
+        this.cardTitle = cardTitle;
+        this.budget = budget;
+        this.deadline = deadline;
+    }
+
+    public static Card toEntity(CreateCardCommand createCardCommand) {
+       return Card.builder()
+           .cardTitle(createCardCommand.cardTitle())
+           .budget(createCardCommand.budget())
+           .deadline(createCardCommand.deadline())
+           .cardStatus(CardStatus.BACKLOG)
+           .build();
+   }
+
+    public String toString() {
+        return """
+            CreateCardCommand{
+                cardTitle='%s',
+                budget='%s',
+                deadline='%s'
+            }
+            """.formatted(cardTitle, budget, deadline);
+    }
+}

--- a/src/main/java/org/wedding/application/port/in/command/card/ModifyCardCommand.java
+++ b/src/main/java/org/wedding/application/port/in/command/card/ModifyCardCommand.java
@@ -1,0 +1,33 @@
+package org.wedding.application.port.in.command.card;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.wedding.domain.CardStatus;
+
+import lombok.Builder;
+
+@Builder
+public record ModifyCardCommand(
+
+    Optional<String> cardTitle,
+    Optional<Long> budget,
+    Optional<LocalDateTime> deadline,
+    Optional<CardStatus> cardStatus
+) {
+
+        public ModifyCardCommand(String cardTitle, Long budget, LocalDateTime deadline, CardStatus cardStatus) {
+            this(Optional.ofNullable(cardTitle), Optional.ofNullable(budget), Optional.ofNullable(deadline), Optional.ofNullable(cardStatus));
+        }
+
+        public String toString() {
+            return """
+                ModifyCardCommand{
+                    cardTitle='%s',
+                    budget='%s',
+                    deadline='%s',
+                    cardStatus='%s'
+                }
+                """.formatted(cardTitle, budget, deadline, cardStatus);
+        }
+}

--- a/src/main/java/org/wedding/application/port/in/usecase/CreateCardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/CreateCardUseCase.java
@@ -1,8 +1,0 @@
-package org.wedding.application.port.in.usecase;
-
-import org.wedding.adapter.in.web.dto.CreateCardRequest;
-
-public interface CreateCardUseCase {
-
-    void createCard(CreateCardRequest request);
-}

--- a/src/main/java/org/wedding/application/port/in/usecase/card/CreateCardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/card/CreateCardUseCase.java
@@ -1,0 +1,8 @@
+package org.wedding.application.port.in.usecase.card;
+
+import org.wedding.application.port.in.command.card.CreateCardCommand;
+
+public interface CreateCardUseCase {
+
+    void createCard(CreateCardCommand command);
+}

--- a/src/main/java/org/wedding/application/port/in/usecase/card/ModifyCardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/card/ModifyCardUseCase.java
@@ -1,8 +1,8 @@
 package org.wedding.application.port.in.usecase.card;
 
-import org.wedding.adapter.in.web.dto.ModifyCardRequest;
+import org.wedding.application.port.in.command.card.ModifyCardCommand;
 
 public interface ModifyCardUseCase {
 
-    void modifyCard(int card, ModifyCardRequest request);
+    void modifyCard(int card, ModifyCardCommand command);
 }

--- a/src/main/java/org/wedding/application/port/in/usecase/card/ModifyCardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/card/ModifyCardUseCase.java
@@ -1,4 +1,4 @@
-package org.wedding.application.port.in.usecase;
+package org.wedding.application.port.in.usecase.card;
 
 import org.wedding.adapter.in.web.dto.ModifyCardRequest;
 

--- a/src/main/java/org/wedding/application/service/CardService.java
+++ b/src/main/java/org/wedding/application/service/CardService.java
@@ -2,8 +2,8 @@ package org.wedding.application.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.wedding.adapter.in.web.dto.ModifyCardRequest;
 import org.wedding.application.port.in.command.card.CreateCardCommand;
+import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.in.usecase.card.CreateCardUseCase;
 import org.wedding.application.port.in.usecase.card.ModifyCardUseCase;
 import org.wedding.application.port.out.repository.CardRepository;
@@ -32,20 +32,20 @@ public class CardService implements CreateCardUseCase, ModifyCardUseCase {
 
     @Transactional
     @Override
-    public void modifyCard(int cardId, ModifyCardRequest request) {
+    public void modifyCard(int cardId, ModifyCardCommand command) {
 
         checkCardExistence(cardId);
         Card card = cardRepository.findByCardId(cardId);
 
-        if (request.cardTitle().isPresent()) {
-            checkDuplicateCardTitle(request.cardTitle().get());
+        if (command.cardTitle().isPresent()) {
+            checkDuplicateCardTitle(command.cardTitle().get());
         }
 
         Card modifiedCard =
-            card.changeCardTitle(request.cardTitle().orElse(card.getCardTitle()))
-                .changeBudget(request.budget().orElse(card.getBudget()))
-                .changeDeadline(request.deadline().orElse(card.getDeadline()))
-                .changeCardStatus(request.cardStatus().orElse(card.getCardStatus()));
+            card.changeCardTitle(command.cardTitle().orElse(card.getCardTitle()))
+                .changeBudget(command.budget().orElse(card.getBudget()))
+                .changeDeadline(command.deadline().orElse(card.getDeadline()))
+                .changeCardStatus(command.cardStatus().orElse(card.getCardStatus()));
 
         cardRepository.save(modifiedCard);
     }

--- a/src/main/java/org/wedding/application/service/CardService.java
+++ b/src/main/java/org/wedding/application/service/CardService.java
@@ -2,10 +2,10 @@ package org.wedding.application.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.wedding.adapter.in.web.dto.CreateCardRequest;
 import org.wedding.adapter.in.web.dto.ModifyCardRequest;
-import org.wedding.application.port.in.usecase.CreateCardUseCase;
-import org.wedding.application.port.in.usecase.ModifyCardUseCase;
+import org.wedding.application.port.in.command.card.CreateCardCommand;
+import org.wedding.application.port.in.usecase.card.CreateCardUseCase;
+import org.wedding.application.port.in.usecase.card.ModifyCardUseCase;
 import org.wedding.application.port.out.repository.CardRepository;
 import org.wedding.domain.card.Card;
 import org.wedding.domain.card.exception.CardError;
@@ -21,9 +21,10 @@ public class CardService implements CreateCardUseCase, ModifyCardUseCase {
 
     @Transactional
     @Override
-    public void createCard(CreateCardRequest request) {
-        checkDuplicateCardTitle(request.cardTitle());
-        Card card = CreateCardRequest.toEntity(request);
+    public void createCard(CreateCardCommand command) {
+
+        checkDuplicateCardTitle(command.cardTitle());
+        Card card = CreateCardCommand.toEntity(command);
 
         cardRepository.save(card);
     }

--- a/src/test/java/org/wedding/application/service/CardServiceTest.java
+++ b/src/test/java/org/wedding/application/service/CardServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.wedding.adapter.in.web.dto.CreateCardRequest;
 import org.wedding.adapter.in.web.dto.ModifyCardRequest;
+import org.wedding.application.port.in.command.card.CreateCardCommand;
 import org.wedding.application.port.out.repository.CardRepository;
 import org.wedding.domain.CardStatus;
 import org.wedding.domain.card.Card;
@@ -31,19 +32,19 @@ class CardServiceTest {
     private CardRepository cardRepository;
 
     private Card card;
-    private CreateCardRequest createCardRequest;
+    private CreateCardCommand createCommand;
     private ModifyCardRequest modifyCardRequest;
 
     @BeforeEach
     void setUp() {
-        createCardRequest = new CreateCardRequest(
+        createCommand = new CreateCardCommand(
             "스드메 예약금 넣기",
             100000L,
             null
         );
         cardService = new CardService(cardRepository);
-        card = CreateCardRequest.toEntity(createCardRequest);
-        cardService.createCard(createCardRequest);
+        card = CreateCardCommand.toEntity(createCommand);
+        cardService.createCard(createCommand);
     }
 
     @DisplayName("카드 제목과 예산 그리고 마감일를 넣으면 카드 생성 성공")
@@ -56,7 +57,7 @@ class CardServiceTest {
             LocalDateTime.now()
         );
         when(cardRepository.existsByCardTitle(allValidCreateCardRequest.cardTitle())).thenReturn(false);
-        cardService.createCard(createCardRequest);
+        cardService.createCard(createCommand);
         verify(cardRepository, times(2)).save(any());
     }
 
@@ -64,13 +65,13 @@ class CardServiceTest {
     @Test
     void createCardWithOnlyTitle() {
 
-        CreateCardRequest createCardWithOnlyTitleRequest = new CreateCardRequest(
+        CreateCardCommand createCardWithOnlyTitleCommand = new CreateCardCommand(
             "결혼식 리허설하기",
             null,
             null
         );
-        when(cardRepository.existsByCardTitle(createCardWithOnlyTitleRequest.cardTitle())).thenReturn(false);
-        cardService.createCard(createCardWithOnlyTitleRequest);
+        when(cardRepository.existsByCardTitle(createCardWithOnlyTitleCommand.cardTitle())).thenReturn(false);
+        cardService.createCard(createCardWithOnlyTitleCommand);
         verify(cardRepository, times(2)).save(any());
     }
 

--- a/src/test/java/org/wedding/application/service/CardServiceTest.java
+++ b/src/test/java/org/wedding/application/service/CardServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.wedding.adapter.in.web.dto.CreateCardRequest;
 import org.wedding.adapter.in.web.dto.ModifyCardRequest;
 import org.wedding.application.port.in.command.card.CreateCardCommand;
+import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.out.repository.CardRepository;
 import org.wedding.domain.CardStatus;
 import org.wedding.domain.card.Card;
@@ -33,7 +34,7 @@ class CardServiceTest {
 
     private Card card;
     private CreateCardCommand createCommand;
-    private ModifyCardRequest modifyCardRequest;
+    private ModifyCardCommand modifyCommand;
 
     @BeforeEach
     void setUp() {
@@ -98,16 +99,16 @@ class CardServiceTest {
     @Test
     void modifyCard_Title() {
 
-        ModifyCardRequest modifyCardTitleRequest = new ModifyCardRequest(
+        ModifyCardCommand modifyCardTitleCommand = new ModifyCardCommand(
             "스드메 예약금 넣기 수정",
             null,
             null,
             null
         );
         lenient().when(cardRepository.existsByCardId(card.getCardId())).thenReturn(true);
-        lenient().when(cardRepository.existsByCardTitle(modifyCardTitleRequest.cardTitle().get())).thenReturn(false);
+        lenient().when(cardRepository.existsByCardTitle(modifyCardTitleCommand.cardTitle().get())).thenReturn(false);
         lenient().when(cardRepository.findByCardId(card.getCardId())).thenReturn(card);
-        cardService.modifyCard(card.getCardId(), modifyCardTitleRequest);
+        cardService.modifyCard(card.getCardId(), modifyCardTitleCommand);
         verify(cardRepository, times(2)).save(any());
     }
 
@@ -132,7 +133,7 @@ class CardServiceTest {
     @Test
     void modifyCard_Status() {
 
-        ModifyCardRequest modifyCardStatusRequest = new ModifyCardRequest(
+        ModifyCardCommand modifyCardStatusCommand = new ModifyCardCommand(
             null,
             null,
             null,
@@ -140,9 +141,9 @@ class CardServiceTest {
         );
 
         lenient().when(cardRepository.existsByCardId(card.getCardId())).thenReturn(true);
-        Assertions.assertThat(modifyCardStatusRequest.cardTitle()).isEqualTo(Optional.empty());
+        Assertions.assertThat(modifyCardStatusCommand.cardTitle()).isEqualTo(Optional.empty());
         lenient().when(cardRepository.findByCardId(card.getCardId())).thenReturn(card);
-        cardService.modifyCard(card.getCardId(), modifyCardStatusRequest);
+        cardService.modifyCard(card.getCardId(), modifyCardStatusCommand);
         verify(cardRepository, times(2)).save(any());
     }
 }


### PR DESCRIPTION
### Isuue Number:
#28 

## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

[ CreateCardRequest 변경사항 ]
- 카드 생성 request가 DTO 역할과 카드 도메인 객체를 생성하는 팩터리 메서드 역할을 수행하고 있었음
- 카드 생성 command 객체를 만들어 카드 도메인 객체를 생성하는 역할을 위임하여 순수한 DTO로 존재하도록 수정

[ ModifyCardRequest 변경사항 ]
- 클라이언트에서 전달받은 데이터를 도메인에 넘겨주는 역할도 했으나 
- 컨트롤러에서 request의 데이터를 command에 전달하여 외부 DTO가 내부 로직와 직접적으로 연결되는걸 막음

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.
- 클라이언트에서 전달한 데이터들을 그대로 내부 서비스, 도메인이 사용되면 오염되거나 캡슐화가 지켜지지 않으므로,
controller에서 내부 데이터를 가지는 command 객체를 내부 애플리케이션에 전달하도록 수정함.


## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.