### PR TITLE
[#37] 도메인 관계 수정: 카드는 투두 도메인을 모르도록 변경

### DIFF
--- a/src/main/java/org/wedding/domain/card/Card.java
+++ b/src/main/java/org/wedding/domain/card/Card.java
@@ -1,9 +1,7 @@
 package org.wedding.domain.card;
 
 import java.time.LocalDate;
-import java.util.List;
 
-import org.wedding.application.port.in.TodoListPort;
 import org.wedding.domain.CardStatus;
 
 import lombok.AllArgsConstructor;
@@ -18,32 +16,23 @@ public class Card {
     private final String cardTitle;
     private final long budget;
     private final LocalDate deadline;   // TODO: Calendar 도메인으로 변경
-    private List<TodoListPort> todoList;
     private final CardStatus cardStatus;
 
-    public Card(int cardId, String cardTitle, long budget, LocalDate deadline, CardStatus cardStatus) {
-        this.cardId = cardId;
-        this.cardTitle = cardTitle;
-        this.budget = budget;
-        this.deadline = deadline;
-        this.cardStatus = cardStatus;
-    }
-
     public Card changeCardTitle(String cardTitle) {
-        return new Card(this.cardId, cardTitle, this.budget, this.deadline, this.todoList, this.cardStatus);
+        return new Card(this.cardId, cardTitle, this.budget, this.deadline, this.cardStatus);
     }
 
     public Card changeBudget(Long budget) {
-        return new Card(this.cardId, this.cardTitle, budget, this.deadline, this.todoList, this.cardStatus);
+        return new Card(this.cardId, this.cardTitle, budget, this.deadline, this.cardStatus);
 
     }
 
     public Card changeDeadline(LocalDate deadline) {
-        return new Card(this.cardId, this.cardTitle, this.budget, deadline, this.todoList, this.cardStatus);
+        return new Card(this.cardId, this.cardTitle, this.budget, deadline, this.cardStatus);
     }
 
     public Card changeCardStatus(CardStatus cardStatus) {
-        return new Card(this.cardId, this.cardTitle, this.budget, this.deadline, this.todoList, cardStatus);
+        return new Card(this.cardId, this.cardTitle, this.budget, this.deadline, cardStatus);
     }
 
     public String toString() {


### PR DESCRIPTION
### Isuue Number:
#37 
## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 투두의 로직이 카드에 영향을 미치지 않아 서로 간의 응집도가 낮다고 판단하여 도메인을 분리해 결합도를 낮춘다.

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.
- 투두는 CardId를 가져서 최소한의 의존성을 가진다.
- 반면, 카드는 투두의 존재를 모른다.

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.