### PR TITLE
[#35] Todo 조회 기능 구현

### DIFF
--- a/src/main/java/org/wedding/adapter/in/web/TodoController.java
+++ b/src/main/java/org/wedding/adapter/in/web/TodoController.java
@@ -20,6 +20,7 @@ import org.wedding.adapter.in.web.dto.todo.UpdateTodoRequset;
 import org.wedding.application.port.in.TodoUseCase;
 import org.wedding.application.port.in.command.todo.CreateTodoCommand;
 import org.wedding.application.port.in.command.todo.DeleteTodoCommand;
+import org.wedding.application.port.in.command.todo.ReadTodoCommand;
 import org.wedding.application.port.in.command.todo.UpdateTodoCommand;
 import org.wedding.common.response.ApiResponse;
 
@@ -89,5 +90,16 @@ public class TodoController {
                     .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
 
             return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/{cardId}/{todoId}")
+    @Operation(summary = "카드에 속한 특정 투두 조회" , description = "카드에 속한 특정 투두 조회")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<TodoResponse> readTodoByCardId(@PathVariable int cardId, @PathVariable int todoId) {
+
+        ReadTodoCommand command = new ReadTodoCommand(cardId, todoId);
+        TodoResponse response = TodoResponse.fromEntity(todoUseCase.readTodo(command));
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/org/wedding/adapter/in/web/TodoController.java
+++ b/src/main/java/org/wedding/adapter/in/web/TodoController.java
@@ -1,9 +1,13 @@
 package org.wedding.adapter.in.web;
 
+import java.util.ArrayList;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +15,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.wedding.adapter.in.web.dto.todo.CreateTodoRequest;
 import org.wedding.adapter.in.web.dto.todo.DeleteTodoRequest;
+import org.wedding.adapter.in.web.dto.todo.TodoResponse;
 import org.wedding.adapter.in.web.dto.todo.UpdateTodoRequset;
 import org.wedding.application.port.in.TodoUseCase;
 import org.wedding.application.port.in.command.todo.CreateTodoCommand;
@@ -71,5 +76,18 @@ public class TodoController {
 
         ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.OK, "투두가 삭제되었습니다.");
         return new ResponseEntity<>(response, response.status());
+    }
+
+    @GetMapping("/{cardId}")
+    @Operation(summary = "카드에 속한 모든 투두 조회", description = "카드에 속한 모든 투두 조회")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<ArrayList<TodoResponse>> readAllTodoByCardId(@PathVariable int cardId) {
+
+            ArrayList<TodoResponse> response =
+                    todoUseCase.getAllTodos(cardId).stream()
+                    .map(TodoResponse::fromEntity)
+                    .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+
+            return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/org/wedding/adapter/in/web/dto/todo/TodoResponse.java
+++ b/src/main/java/org/wedding/adapter/in/web/dto/todo/TodoResponse.java
@@ -1,0 +1,16 @@
+package org.wedding.adapter.in.web.dto.todo;
+
+import org.wedding.application.service.response.todo.TodoDto;
+import org.wedding.domain.todo.TodoCheckStatus;
+
+public record TodoResponse (
+    int cardId,
+    int todoId,
+    String todoItem,
+    TodoCheckStatus todoCheckStatus
+) {
+
+    public static TodoResponse fromEntity(TodoDto todoDto) {
+        return new TodoResponse(todoDto.cardId(), todoDto.todoId(), todoDto.todoItem(), todoDto.todoCheckStatus());
+    }
+}

--- a/src/main/java/org/wedding/adapter/out/persistence/MybatisTodoRepositoryImpl.java
+++ b/src/main/java/org/wedding/adapter/out/persistence/MybatisTodoRepositoryImpl.java
@@ -25,5 +25,4 @@ public interface MybatisTodoRepositoryImpl extends TodoRepository {
     void deleteTodo(int cardId, int todoId);
     @Override
     ArrayList<Todo> getAllTodos(int cardId);
-    // Todo readTodo(int cardId, int todoId);
 }

--- a/src/main/java/org/wedding/adapter/out/persistence/MybatisTodoRepositoryImpl.java
+++ b/src/main/java/org/wedding/adapter/out/persistence/MybatisTodoRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.wedding.adapter.out.persistence;
 
+import java.util.ArrayList;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.stereotype.Repository;
 import org.wedding.application.port.out.repository.TodoRepository;
@@ -21,4 +23,7 @@ public interface MybatisTodoRepositoryImpl extends TodoRepository {
     boolean existsByTodoId(int cardId, int todoId);
     @Override
     void deleteTodo(int cardId, int todoId);
+    @Override
+    ArrayList<Todo> getAllTodos(int cardId);
+    // Todo readTodo(int cardId, int todoId);
 }

--- a/src/main/java/org/wedding/application/port/in/TodoUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/TodoUseCase.java
@@ -1,15 +1,16 @@
 package org.wedding.application.port.in;
 
+import java.util.ArrayList;
+
 import org.wedding.application.port.in.command.todo.CreateTodoCommand;
 import org.wedding.application.port.in.command.todo.DeleteTodoCommand;
 import org.wedding.application.port.in.command.todo.UpdateTodoCommand;
+import org.wedding.application.service.response.todo.TodoDto;
 
 public interface TodoUseCase {
     void createTodo(CreateTodoCommand command);
     void updateTodo(UpdateTodoCommand command);
     void deleteTodo(DeleteTodoCommand command);
-
-    /* TODO
-      List<Todo> getAllTodos(int cardId);
-     */
+    ArrayList<TodoDto> getAllTodos(int cardId);
+    // TodosDto readTodo(ReadTodoCommand command);
 }

--- a/src/main/java/org/wedding/application/port/in/TodoUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/TodoUseCase.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import org.wedding.application.port.in.command.todo.CreateTodoCommand;
 import org.wedding.application.port.in.command.todo.DeleteTodoCommand;
+import org.wedding.application.port.in.command.todo.ReadTodoCommand;
 import org.wedding.application.port.in.command.todo.UpdateTodoCommand;
 import org.wedding.application.service.response.todo.TodoDto;
 
@@ -12,5 +13,5 @@ public interface TodoUseCase {
     void updateTodo(UpdateTodoCommand command);
     void deleteTodo(DeleteTodoCommand command);
     ArrayList<TodoDto> getAllTodos(int cardId);
-    // TodosDto readTodo(ReadTodoCommand command);
+    TodoDto readTodo(ReadTodoCommand command);
 }

--- a/src/main/java/org/wedding/application/port/in/command/todo/ReadTodoCommand.java
+++ b/src/main/java/org/wedding/application/port/in/command/todo/ReadTodoCommand.java
@@ -1,0 +1,8 @@
+package org.wedding.application.port.in.command.todo;
+
+import org.wedding.application.port.in.command.card.HasCardId;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ReadTodoCommand(@NotNull int cardId, @NotNull int todoId) implements HasCardId {
+}

--- a/src/main/java/org/wedding/application/port/out/repository/TodoRepository.java
+++ b/src/main/java/org/wedding/application/port/out/repository/TodoRepository.java
@@ -13,6 +13,4 @@ public interface TodoRepository {
     boolean existsByTodoId(int cardId, int todoId);
     void deleteTodo(int cardId, int todoId);
     ArrayList<Todo> getAllTodos(int cardId);
-    // Todo readTodo(int cardId, int todoId);
-
 }

--- a/src/main/java/org/wedding/application/port/out/repository/TodoRepository.java
+++ b/src/main/java/org/wedding/application/port/out/repository/TodoRepository.java
@@ -1,5 +1,7 @@
 package org.wedding.application.port.out.repository;
 
+import java.util.ArrayList;
+
 import org.wedding.domain.todo.Todo;
 
 public interface TodoRepository {
@@ -10,8 +12,7 @@ public interface TodoRepository {
     Todo findByTodoId(int cardId, int todoId);
     boolean existsByTodoId(int cardId, int todoId);
     void deleteTodo(int cardId, int todoId);
+    ArrayList<Todo> getAllTodos(int cardId);
+    // Todo readTodo(int cardId, int todoId);
 
-    /* TODO
-      List<Todo> getAllTodos(int cardId);
-     */
 }

--- a/src/main/java/org/wedding/application/service/TodoService.java
+++ b/src/main/java/org/wedding/application/service/TodoService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.wedding.application.port.in.TodoUseCase;
 import org.wedding.application.port.in.command.todo.CreateTodoCommand;
 import org.wedding.application.port.in.command.todo.DeleteTodoCommand;
+import org.wedding.application.port.in.command.todo.ReadTodoCommand;
 import org.wedding.application.port.in.command.todo.UpdateTodoCommand;
 import org.wedding.application.port.out.repository.TodoRepository;
 import org.wedding.application.service.response.todo.TodoDto;
@@ -74,6 +75,16 @@ public class TodoService implements TodoUseCase {
         }
 
         return todoDto;
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public TodoDto readTodo(ReadTodoCommand command) {
+
+        checkTodoExistence(command.cardId(), command.todoId());
+        Todo todo = todoRepository.findByTodoId(command.cardId(), command.todoId());
+
+        return TodoDto.fromEntity(todo);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/wedding/application/service/TodoService.java
+++ b/src/main/java/org/wedding/application/service/TodoService.java
@@ -1,5 +1,8 @@
 package org.wedding.application.service;
 
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.wedding.application.port.in.TodoUseCase;
@@ -7,6 +10,7 @@ import org.wedding.application.port.in.command.todo.CreateTodoCommand;
 import org.wedding.application.port.in.command.todo.DeleteTodoCommand;
 import org.wedding.application.port.in.command.todo.UpdateTodoCommand;
 import org.wedding.application.port.out.repository.TodoRepository;
+import org.wedding.application.service.response.todo.TodoDto;
 import org.wedding.config.anotation.CheckCardExistence;
 import org.wedding.domain.todo.Todo;
 import org.wedding.domain.todo.exception.TodoError;
@@ -55,6 +59,21 @@ public class TodoService implements TodoUseCase {
 
         checkTodoExistence(command.cardId(), command.todoId());
         todoRepository.deleteTodo(command.cardId(), command.todoId());
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public ArrayList<TodoDto> getAllTodos(int cardId) {
+
+        ArrayList<TodoDto> todoDto = todoRepository.getAllTodos(cardId).stream()
+                .map(TodoDto::fromEntity)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        if (todoDto.isEmpty()) {
+            throw new TodoException(TodoError.TODO_NOT_FOUND);
+        }
+
+        return todoDto;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/wedding/application/service/response/todo/TodoDto.java
+++ b/src/main/java/org/wedding/application/service/response/todo/TodoDto.java
@@ -1,0 +1,17 @@
+package org.wedding.application.service.response.todo;
+
+import org.wedding.domain.todo.Todo;
+import org.wedding.domain.todo.TodoCheckStatus;
+
+public record TodoDto(
+
+    int cardId,
+    int todoId,
+    String todoItem,
+    TodoCheckStatus todoCheckStatus
+) {
+
+    public static TodoDto fromEntity(Todo todo) {
+        return new TodoDto(todo.getCardId(), todo.getTodoId(), todo.getTodoItem(), todo.getTodoCheckStatus());
+    }
+}

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -4,6 +4,13 @@
 
 <mapper namespace="org.wedding.adapter.out.persistence.MybatisTodoRepositoryImpl">
 
+    <resultMap id="todoResultMap" type="Todo">
+        <id column="todo_id" property="todoId"/>
+        <result column="todo_item" property="todoItem"/>
+        <result column="todo_check_status" property="todoCheckStatus"/>
+        <result column="card_id" property="cardId"/>
+    </resultMap>
+
     <insert id="save" parameterType="Todo" useGeneratedKeys="true" keyProperty="todoId">
         INSERT INTO todo (todo_id, todo_item, todo_check_status, card_id)
         VALUES (#{todoId}, #{todoItem}, #{todoCheckStatus}, #{cardId})
@@ -33,5 +40,11 @@
     <delete id="deleteTodo" parameterType="int">
         DELETE FROM todo WHERE todo_id = #{todoId} AND card_id = #{cardId}
     </delete>
+    
+    <select id="getAllTodos" resultType="arraylist" resultMap="todoResultMap">
+        SELECT todo_id, todo_item, todo_check_status, card_id
+        FROM todo
+        WHERE card_id = #{cardId}
+    </select>
 
 </mapper>

--- a/src/test/java/org/wedding/application/service/TodoServiceTest.java
+++ b/src/test/java/org/wedding/application/service/TodoServiceTest.java
@@ -1,12 +1,12 @@
 package org.wedding.application.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.wedding.domain.todo.TodoCheckStatus.*;
 
 import java.util.ArrayList;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 import org.wedding.application.port.in.command.todo.CreateTodoCommand;
 import org.wedding.application.port.in.command.todo.DeleteTodoCommand;
+import org.wedding.application.port.in.command.todo.ReadTodoCommand;
 import org.wedding.application.port.in.command.todo.UpdateTodoCommand;
 import org.wedding.application.port.out.repository.TodoRepository;
 import org.wedding.application.service.response.todo.TodoDto;
@@ -34,6 +35,7 @@ class TodoServiceTest {
     private CreateTodoCommand createCommand;
     private UpdateTodoCommand updateCommand;
     private DeleteTodoCommand deleteCommand;
+    private ReadTodoCommand   readCommand;
 
     @BeforeEach
     void setUp() {
@@ -135,7 +137,7 @@ class TodoServiceTest {
 
         // then
         verify(todoRepository).getAllTodos(1);
-        Assertions.assertThat(todoDto.get(0).todoItem()).isEqualTo("할일");
+        assertThat(todoDto.get(0).todoItem()).isEqualTo("할일");
     }
 
     @DisplayName("특정 카드에 속한 모든 todo를 조회할 때 todo가 없으면 예외를 발생시킨다.")
@@ -144,5 +146,30 @@ class TodoServiceTest {
 
         when(todoRepository.getAllTodos(anyInt())).thenReturn(new ArrayList<>()); // todo가 없는 경우, 빈 리스트 반환
         assertThrows(TodoException.class, () -> todoService.getAllTodos(anyInt()));
+    }
+
+    @DisplayName("특정 카드에 속한 특정 todo를 조회한다.")
+    @Test
+    void readTodo_Success() {
+
+        // given
+        when(todoRepository.existsByTodoId(1, 1)).thenReturn(true);
+        when(todoRepository.findByTodoId(1, 1)).thenReturn(todo);
+
+        // when
+        readCommand = new ReadTodoCommand(1, 1);
+        TodoDto todoDto = todoService.readTodo(readCommand);
+
+        // then
+        verify(todoRepository).findByTodoId(1, 1);
+        assertThat(todoDto.todoItem()).isEqualTo("할일");
+    }
+
+    @DisplayName("특정 카드에 속한 특정 todo를 조회할 때 todo가 없으면 예외를 발생시킨다.")
+    @Test
+    void readTodo_Fail_WhenTodoNotExist() {
+
+        when(todoRepository.existsByTodoId(1, 1)).thenReturn(false);
+        assertThrows(TodoException.class, () -> todoService.checkTodoExistence(1, 1));
     }
 }

--- a/src/test/java/org/wedding/application/service/TodoServiceTest.java
+++ b/src/test/java/org/wedding/application/service/TodoServiceTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.wedding.domain.todo.TodoCheckStatus.*;
 
+import java.util.ArrayList;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +19,7 @@ import org.wedding.application.port.in.command.todo.CreateTodoCommand;
 import org.wedding.application.port.in.command.todo.DeleteTodoCommand;
 import org.wedding.application.port.in.command.todo.UpdateTodoCommand;
 import org.wedding.application.port.out.repository.TodoRepository;
+import org.wedding.application.service.response.todo.TodoDto;
 import org.wedding.domain.todo.Todo;
 import org.wedding.domain.todo.exception.TodoException;
 
@@ -115,5 +119,30 @@ class TodoServiceTest {
 
         when(todoRepository.existsByTodoId(anyInt(), anyInt())).thenReturn(false);
         assertThrows(TodoException.class, () -> todoService.checkTodoExistence(anyInt(), anyInt()));
+    }
+
+    @DisplayName("특정 카드에 속한 모든 todo를 조회한다.")
+    @Test
+    void getAllTodos_Success() {
+
+        // given
+        ArrayList<Todo> todos = new ArrayList<>();
+        todos.add(todo);
+
+        // when
+        when(todoRepository.getAllTodos(1)).thenReturn(todos);
+        ArrayList<TodoDto> todoDto = todoService.getAllTodos(1);
+
+        // then
+        verify(todoRepository).getAllTodos(1);
+        Assertions.assertThat(todoDto.get(0).todoItem()).isEqualTo("할일");
+    }
+
+    @DisplayName("특정 카드에 속한 모든 todo를 조회할 때 todo가 없으면 예외를 발생시킨다.")
+    @Test
+    void getAllTodos_Fail_WhenTodoNotExist() {
+
+        when(todoRepository.getAllTodos(anyInt())).thenReturn(new ArrayList<>()); // todo가 없는 경우, 빈 리스트 반환
+        assertThrows(TodoException.class, () -> todoService.getAllTodos(anyInt()));
     }
 }


### PR DESCRIPTION
### Isuue Number:
#35 
## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- DTO와 Response를 구분한다.
- 각 계층별로 데이터 객체를 맵핑하여 계층 분리 시키다.
- `fromEntity` 메소드로 의존성 방향성을 명시한다.
- 테스트 커버리지 80% 이상 달성

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.
- DB에서 조회한 도메인 객체를 DTO로 변환하는걸 명시하고 클라이언트에 반환하는 데이터 객체를 Response로 구분한다.
- service 계층의 DTO를 직접 클라이언트에 반환시 API 스펙 변경시 service 계층의 코드 수정이 불가피하므로 데이터 맵칭으로 계층 분리시킨다.
- `fromEntity` 명칭은 객체 변환의 방향성을 나타내며 DB에서 조회한 도메인 객체를 DTO로 변환하는걸 의미한다.

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.