### PR TITLE
[#55] 로그인시 세션 적재 및 조회 기능 구현

### DIFF
--- a/src/main/java/org/wedding/adapter/in/web/UserController.java
+++ b/src/main/java/org/wedding/adapter/in/web/UserController.java
@@ -11,6 +11,7 @@ import org.wedding.application.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,9 +40,9 @@ public class UserController {
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "로그인")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<ApiResponse<Void>> login(@RequestBody @Valid LoginDTO request) {
+    public ResponseEntity<ApiResponse<Void>> login(@RequestBody @Valid LoginDTO request, HttpSession session) {
         ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.OK, "로그인 성공했습니다.");
-        userService.login(request);
+        userService.login(request, session);
         return new ResponseEntity<>(response, response.status());
     }
 

--- a/src/main/java/org/wedding/adapter/in/web/security/SessionUtils.java
+++ b/src/main/java/org/wedding/adapter/in/web/security/SessionUtils.java
@@ -1,0 +1,20 @@
+package org.wedding.adapter.in.web.security;
+
+import java.util.Optional;
+
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.wedding.domain.user.exception.UserError;
+import org.wedding.domain.user.exception.UserException;
+
+public class SessionUtils {
+
+    public static int getCurrentUserId() {
+
+        return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
+            .map(attributes -> ((ServletRequestAttributes)attributes).getRequest().getSession(false))
+            .map(session -> session.getAttribute("userId"))
+            .map(userId -> (int)userId)
+            .orElseThrow(() -> new UserException(UserError.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/wedding/application/service/UserService.java
+++ b/src/main/java/org/wedding/application/service/UserService.java
@@ -8,6 +8,7 @@ import org.wedding.domain.user.User;
 import org.wedding.domain.user.exception.UserError;
 import org.wedding.application.port.out.repository.UserRepository;
 
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 
 import org.wedding.domain.user.exception.UserException;
@@ -39,7 +40,7 @@ public class UserService {
     }
 
     // TODO: UserDto를 User로 바꾸기
-    public void login(LoginDTO request) {
+    public void login(LoginDTO request, HttpSession session) {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new UserException(UserError.USER_NOT_FOUND));
 
@@ -49,8 +50,7 @@ public class UserService {
 
         UserDto.of(user);
 
-    //     session.setAttribute("user", user.getId());
-    //     System.out.println("session.getId() = " + session.getId());
+        session.setAttribute("userId", user.getId());
     }
 
     private boolean equals(String password, String password1) {

--- a/src/test/java/org/wedding/adapter/in/web/security/SessionUtilsTest.java
+++ b/src/test/java/org/wedding/adapter/in/web/security/SessionUtilsTest.java
@@ -1,0 +1,62 @@
+package org.wedding.adapter.in.web.security;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.wedding.domain.user.exception.UserException;
+
+class SessionUtilsTest {
+
+    private MockHttpSession session;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+
+        session = new MockHttpSession();
+        request = new MockHttpServletRequest();
+        request.setSession(session);
+    }
+
+    @Test
+    void getCurrentUserId_WhenSuccess() {
+
+        // given
+        int expectedUserId = 1;
+        session.setAttribute("userId", expectedUserId);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        // when
+        int actualUserId = SessionUtils.getCurrentUserId();
+
+        // then
+        assertThat(actualUserId).isEqualTo(expectedUserId);
+    }
+
+    @Test
+    void getCurrentUserId_WhenSessionIsNull() {
+
+        // given: 세션 설정 하지 않음
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, null));
+
+        // then
+        assertThrows(UserException.class, SessionUtils::getCurrentUserId);
+    }
+
+    @Test
+    void getCurrentUserId_WhenUserIdIsNull() {
+
+        // given
+        session.setAttribute("userId", null);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        // then
+        assertThrows(UserException.class, SessionUtils::getCurrentUserId);
+    }
+}


### PR DESCRIPTION
### Isuue Number:
#55 
- related to: #54 

## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.
세션 저장으로 userId 조회를 서비스 로직에서 분리시킨다.

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.
- 세션은 HTTP 레이어여서 컨트롤러 패키지에 위치시킴
- 인증/인가 패키지를 만들어 서비스 컨트롤러와 논리적 분리함
  - 특정 컨트롤러에 종속되지 않다고 판단함
- 커버리지 80% 이상

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.